### PR TITLE
store upload directory id for followup submissions

### DIFF
--- a/migrations/versions/2c76c101e8eb_bluebeam_project_db_support.py
+++ b/migrations/versions/2c76c101e8eb_bluebeam_project_db_support.py
@@ -1,0 +1,27 @@
+# pylint: skip-file
+"""bluebeam project db support
+
+Revision ID: 2c76c101e8eb
+Revises: afc36c789b78
+Create Date: 2020-05-08 13:49:56.473672
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2c76c101e8eb'
+down_revision = 'afc36c789b78'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('submission',
+        sa.Column('upload_dir_id', sa.Integer)
+    )
+
+
+def downgrade():
+    op.drop_column('submission', 'upload_dir_id')

--- a/service/resources/models.py
+++ b/service/resources/models.py
@@ -32,6 +32,7 @@ class SubmissionModel(BASE):
         sa.ForeignKey('export_status.guid')
     )
     export_status = relationship('ExportStatusModel', foreign_keys=[export_status_guid])
+    upload_dir_id = sa.Column('upload_dir_id', sa.Integer)
 
 def create_submission(db_session, json_data):
     """helper function for creating a submission"""

--- a/tasks.py
+++ b/tasks.py
@@ -83,6 +83,7 @@ def bluebeam_export(self, export_obj, access_code):
                 statuses['success'].append(submission.id)
                 submission.date_exported = datetime.utcnow()
                 submission.bluebeam_project_id = project_id
+                submission.pdf_folder_id = pdf_folder_id
             else:
                 print(ERR_NO_PDF_FOLDER)
                 raise Exception(ERR_NO_PDF_FOLDER)

--- a/tasks.py
+++ b/tasks.py
@@ -83,7 +83,7 @@ def bluebeam_export(self, export_obj, access_code):
                 statuses['success'].append(submission.id)
                 submission.date_exported = datetime.utcnow()
                 submission.bluebeam_project_id = project_id
-                submission.pdf_folder_id = pdf_folder_id
+                submission.upload_dir_id = pdf_folder_id
             else:
                 print(ERR_NO_PDF_FOLDER)
                 raise Exception(ERR_NO_PDF_FOLDER)


### PR DESCRIPTION
create column in database to store upload directory id and then populate the column after creating the project/directory in bluebeam.
storing it for future support of followup submissions.